### PR TITLE
Update pytr to 0,43 and use bullseye image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
-ARG debian_version=slim-buster
+ARG debian_version=slim-bullseye
 ARG python_version=3.10
-ARG pytr_tag=v0.4.2
+ARG pytr_tag=v0.4.3
 
 FROM python:${python_version}-${debian_version} AS builder
 ARG pytr_tag


### PR DESCRIPTION
Buster is EOL and the repos have been moved to `archive.debian.org`

Pytr changelog: https://github.com/pytr-org/pytr/releases/tag/v0.4.3